### PR TITLE
Add background thread to call consumer heartbeat hook with fixed period

### DIFF
--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -109,6 +109,18 @@ It's recommended that this function be declared with ``**kwargs`` so it doesn't 
 
 optional; fully-qualified function name
 
+**TASKHAWK_HEARTBEAT_HOOK**
+
+A function which can be used to report the taskhawk consumer health state.
+
+optional; fully-qualified function name
+
+**TASKHAWK_HEARTBEAT_HOOK_SYNC_CALL_S**
+
+Specifies the period of time in seconds at which the heartbeat hook function will be called.
+
+optional; positive int or float
+
 **TASKHAWK_PRE_PROCESS_HOOK**
 
 A function which can used to plug into the message processing pipeline *before* any processing happens. This hook

--- a/taskhawk/backends/base.py
+++ b/taskhawk/backends/base.py
@@ -187,6 +187,12 @@ class TaskhawkConsumerBaseBackend(TaskhawkBaseBackend):
     def nack_message(self, queue_message) -> None:
         raise NotImplementedError
 
+    def call_heartbeat_hook(self):
+        try:
+            settings.TASKHAWK_HEARTBEAT_HOOK(**self.heartbeat_hook_kwargs())
+        except Exception:
+            logger.exception('Exception in heartbeat hook')
+
     @staticmethod
     def _build_message(message_json: str, provider_metadata) -> Message:
         try:

--- a/taskhawk/backends/gcp.py
+++ b/taskhawk/backends/gcp.py
@@ -216,10 +216,10 @@ class GooglePubSubConsumerBackend(TaskhawkConsumerBaseBackend):
             self._error_count += 1
             return []
         finally:
-            self._call_heartbeat_hook()
+            self.call_heartbeat_hook()
 
     def process_message(self, queue_message: ReceivedMessage) -> None:
-        self._call_heartbeat_hook()
+        self.call_heartbeat_hook()
         self.message_handler(
             queue_message.message.data.decode(),
             GoogleMetadata(queue_message.ack_id, queue_message.message.publish_time, queue_message.delivery_attempt),
@@ -262,7 +262,7 @@ class GooglePubSubConsumerBackend(TaskhawkConsumerBaseBackend):
         self.subscriber.modify_ack_deadline(
             subscription=self._subscription_path, ack_ids=[ack_id], ack_deadline_seconds=visibility_timeout_s
         )
-        self._call_heartbeat_hook()
+        self.call_heartbeat_hook()
 
     def requeue_dead_letter(self, num_messages: int = 10, visibility_timeout: Optional[int] = None) -> None:
         """
@@ -308,9 +308,3 @@ class GooglePubSubConsumerBackend(TaskhawkConsumerBaseBackend):
                     )
 
             logging.info("Re-queued {} messages".format(len(queue_messages)))
-
-    def _call_heartbeat_hook(self):
-        try:
-            settings.TASKHAWK_HEARTBEAT_HOOK(**self.heartbeat_hook_kwargs())
-        except Exception:
-            logger.exception('Exception in heartbeat hook')

--- a/taskhawk/conf/__init__.py
+++ b/taskhawk/conf/__init__.py
@@ -38,6 +38,7 @@ _DEFAULTS = {
     'TASKHAWK_CONSUMER_BACKEND': None,
     'TASKHAWK_DEFAULT_HEADERS': 'taskhawk.conf.default_headers_hook',
     'TASKHAWK_HEARTBEAT_HOOK': 'taskhawk.conf.noop_hook',
+    'TASKHAWK_HEARTBEAT_HOOK_SYNC_CALL_S': None,
     'TASKHAWK_PRE_PROCESS_HOOK': 'taskhawk.conf.noop_hook',
     'TASKHAWK_POST_PROCESS_HOOK': 'taskhawk.conf.noop_hook',
     'TASKHAWK_PUBLISHER_BACKEND': None,

--- a/taskhawk/consumer.py
+++ b/taskhawk/consumer.py
@@ -3,6 +3,8 @@ import threading
 from typing import Optional
 
 from taskhawk.backends.utils import get_consumer_backend
+from taskhawk.conf import settings
+from taskhawk.heartbeat import start_periodic_heartbeat_hook_thread
 from taskhawk.models import Priority
 
 
@@ -53,6 +55,11 @@ def listen_for_messages(
         shutdown_event = threading.Event()
 
     consumer_backend = get_consumer_backend(priority=priority)
+    if settings.TASKHAWK_HEARTBEAT_HOOK_SYNC_CALL_S is not None:
+        start_periodic_heartbeat_hook_thread(
+            consumer_backend, settings.TASKHAWK_HEARTBEAT_HOOK_SYNC_CALL_S, shutdown_event
+        )
+
     for count in itertools.count():
         if (loop_count is None or count < loop_count) and not shutdown_event.is_set():
             consumer_backend.fetch_and_process_messages(

--- a/taskhawk/heartbeat.py
+++ b/taskhawk/heartbeat.py
@@ -1,0 +1,30 @@
+import logging
+import threading
+from time import sleep
+from typing import Union
+
+from taskhawk.backends.base import TaskhawkConsumerBaseBackend
+
+logger = logging.getLogger(__name__)
+
+
+def start_periodic_heartbeat_hook_thread(
+    consumer_backend: TaskhawkConsumerBaseBackend, delay_s: Union[int, float], shutdown_event: threading.Event
+) -> threading.Thread:
+    if delay_s <= 0:
+        raise ValueError("delay_s must be greater than zero")
+    heartbeat_hook_thread = threading.Thread(
+        target=periodic_heartbeat_hook, args=(consumer_backend, delay_s, shutdown_event), daemon=True
+    )
+    heartbeat_hook_thread.start()
+    logger.debug("Periodic heartbeat hook thread has started")
+    return heartbeat_hook_thread
+
+
+def periodic_heartbeat_hook(
+    consumer_backend: TaskhawkConsumerBaseBackend, delay_s: Union[int, float], shutdown_event: threading.Event
+) -> None:
+    while not shutdown_event.is_set():
+        consumer_backend.call_heartbeat_hook()
+        logger.debug("Periodic heartbeat hook was called")
+        sleep(delay_s)

--- a/tests/test_consumer.py
+++ b/tests/test_consumer.py
@@ -28,3 +28,18 @@ class TestListenForMessages:
         mock_get_backend.return_value.fetch_and_process_messages.assert_called_once_with(
             num_messages=num_messages, visibility_timeout=visibility_timeout_s
         )
+
+    def test_listen_for_messages_with_periodic_heartbeat_thread(self, mock_get_backend, settings):
+        num_messages = 3
+        visibility_timeout_s = 4
+        loop_count = 1
+        priority = Priority.default
+        settings.TASKHAWK_HEARTBEAT_HOOK_SYNC_CALL_S = 1
+
+        listen_for_messages(priority, num_messages, visibility_timeout_s, loop_count)
+
+        mock_get_backend.assert_called_once_with(priority=priority)
+        mock_get_backend.return_value.fetch_and_process_messages.assert_called_once_with(
+            num_messages=num_messages, visibility_timeout=visibility_timeout_s
+        )
+        mock_get_backend.return_value.call_heartbeat_hook.assert_called_once_with()

--- a/tests/test_heartbeat.py
+++ b/tests/test_heartbeat.py
@@ -1,0 +1,29 @@
+import threading
+from time import sleep
+from unittest import mock
+
+from taskhawk.backends.base import TaskhawkConsumerBaseBackend
+from taskhawk.heartbeat import start_periodic_heartbeat_hook_thread
+
+
+class DummyConsumer(TaskhawkConsumerBaseBackend):
+    pass
+
+
+heartbeat_hook = mock.Mock(name='heartbeat_hook')
+
+
+def test_start_periodic_heartbeat_hook_thread(settings):
+    heartbeat_hook.reset_mock()
+    consumer = DummyConsumer()
+    shutdown_event = threading.Event()
+    settings.TASKHAWK_HEARTBEAT_HOOK = 'tests.test_heartbeat.heartbeat_hook'
+    settings.TASKHAWK_HEARTBEAT_HOOK_SYNC_CALL_S = 0.4
+
+    heartbeat_hook_thread = start_periodic_heartbeat_hook_thread(consumer, 0.2, shutdown_event)
+    sleep(1)
+    shutdown_event.set()
+    sleep(0.3)
+
+    assert heartbeat_hook.call_count >= 5
+    assert not heartbeat_hook_thread.is_alive()


### PR DESCRIPTION
Add background thread to call consumer heartbeat hook with fixed period. 

Currently taskhawk consumer process runs in a single thread mode and it calls the heartbeat hook function before and after message is processed. Heartbeat function is used to determine the taskhawk consumer process health check status. When message processing takes longer, heartbeat function is not called for longer period, which may cause that taskhawk health check status is not up-to-date or even expired (if hc status data has predefined ttl) - which results in hc readiness 503 errors. Calling heartbeat function with predefined period should eliminate above issues.
